### PR TITLE
allow distinction of python3 for systems with both installed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ dmypy.json
 .pyre/
 
 miniwdl_omics_run/_version.py
+
+# IntelliJ/ PyCharm
+.idea/

--- a/release.sh
+++ b/release.sh
@@ -1,8 +1,13 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 
 cd "$(dirname "$0")"
 rm -rf dist/
-python -m build --sdist --wheel
+if [[ "$(python3 -V)" =~ "Python 3" ]]; then
+	PY=python3
+else
+	PY=python
+fi
+$PY -m build --sdist --wheel
 twine upload dist/*


### PR DESCRIPTION
Some older systems like Amazon Linux2 still have python 2 installed as `python` and python 3 as `python3`. In addition, some newer systems don't have `python` at all and only use `python3` and using aliases is not usually compatible with shell scripts. 